### PR TITLE
Made arrow head face the viewer

### DIFF
--- a/Runtime/Scripts/LineDrawer.cs
+++ b/Runtime/Scripts/LineDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using UdonSharp;
 using UnityEngine;
+using VRC.SDKBase;
 
 namespace OrchidSeal.ParaDraw
 {
@@ -21,23 +22,11 @@ namespace OrchidSeal.ParaDraw
 
         private readonly Vector3[] arrowheadVertices = new Vector3[]
         {
-            new Vector3(-1.0f, -1.0f, -1.4142f),
+            new Vector3(0.0f, 0.0f, -1.4142f),
+            new Vector3(-1.0f, 0.0f, -1.4142f),
             new Vector3(0.0f, 0.0f, 0.0f),
-            new Vector3(-1.0f, -1.0f, -1.4142f),
-
-            new Vector3(1.0f, -1.0f, -1.4142f),
-            new Vector3(0.0f, 0.0f, 0.0f),
-            new Vector3(1.0f, -1.0f, -1.4142f),
-
-            new Vector3(1.0f, 1.0f, -1.4142f),
-            new Vector3(0.0f, 0.0f, 0.0f),
-            new Vector3(1.0f, 1.0f, -1.4142f),
-
-            new Vector3(-1.0f, 1.0f, -1.4142f),
-            new Vector3(0.0f, 0.0f, 0.0f),
-            new Vector3(-1.0f, 1.0f, -1.4142f),
-
-            new Vector3(-1.0f, -1.0f, -1.4142f),
+            new Vector3(1.0f, 0.0f, -1.4142f),
+            new Vector3(0.0f, 0.0f, -1.4142f),
         };
 
         private readonly Vector3[] boxVertices = new Vector3[]
@@ -160,11 +149,15 @@ namespace OrchidSeal.ParaDraw
 
         public void DrawRay(Vector3 origin, Vector3 direction, Color color, float lineWidth = 0.005f, float duration = 0.0f)
         {
-            var end = origin + direction;
-            DrawLine(origin, end, color, lineWidth, duration);
+            var arrowheadScale = 0.1f * Mathf.Min(direction.magnitude, 0.2f);
 
-            var arrowheadScale = (0.1f * Mathf.Min(direction.magnitude, 0.2f)) * Vector3.one;
-            DrawPolyline(arrowheadVertices, end, Quaternion.LookRotation(direction), arrowheadScale, color, lineWidth, duration);
+            var end = origin + direction;
+            DrawLine(origin, end - direction.normalized * (arrowheadScale * 1.4142f), color, lineWidth, duration);
+
+            var headPos = Networking.LocalPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head).position;
+            var right = Vector3.Cross(direction, headPos - end).normalized;
+            var forward = Vector3.Cross(right, direction).normalized;
+            DrawPolyline(arrowheadVertices, end, Quaternion.LookRotation(direction, forward), arrowheadScale * Vector3.one, color, lineWidth, duration);
         }
 
         public void DrawWireBox(Vector3 center, Quaternion rotation, Vector3 size, Color color, float lineWidth = 0.005f, float duration = 0.0f)

--- a/Runtime/Scripts/LineDrawer.cs
+++ b/Runtime/Scripts/LineDrawer.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
 
@@ -15,6 +16,8 @@ namespace OrchidSeal.ParaDraw
         public LineRenderer[] lineRenderers = new LineRenderer[16];
         public GameObject linesGroup;
 
+        private VRCPlayerApi _localPlayer;
+        
         private float[] lineDurations = new float[16];
         private int lineIndexEnd;
         private Material[] lineMaterials = new Material[16];
@@ -63,6 +66,11 @@ namespace OrchidSeal.ParaDraw
 
             new Vector3(-0.5f, -0.5f, 0.0f),
         };
+
+        private void Start()
+        {
+            _localPlayer = Networking.LocalPlayer;
+        }
 
         public void DrawEllipse(Vector3 center, Vector3 axisX, Vector3 axisY, Vector2 radii, Color color, float lineWidth = 0.005f, float duration = 0.0f)
         {
@@ -154,7 +162,8 @@ namespace OrchidSeal.ParaDraw
             var end = origin + direction;
             DrawLine(origin, end - direction.normalized * (arrowheadScale * 1.4142f), color, lineWidth, duration);
 
-            var headPos = Networking.LocalPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head).position;
+            var headData = _localPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head);
+            var headPos = headData.position;
             var right = Vector3.Cross(direction, headPos - end).normalized;
             var forward = Vector3.Cross(right, direction).normalized;
             DrawPolyline(arrowheadVertices, end, Quaternion.LookRotation(direction, forward), arrowheadScale * Vector3.one, color, lineWidth, duration);


### PR DESCRIPTION
I replaced the arrow head drawing to make it face the viewer whilst still being limited to rotating around its axis.
The reason I did this was to reduce the visual complexity of the previous pyramid that was used to draw it the head.